### PR TITLE
Switch to german language model in tests

### DIFF
--- a/tests/test_dehyphen.py
+++ b/tests/test_dehyphen.py
@@ -6,8 +6,7 @@ from dehyphen import FlairScorer, format_to_paragraph, text_to_format
 
 @pytest.fixture()
 def flair_scorer():
-    # fast (small) model that also includes German
-    scorer = FlairScorer(lang="multi-v0", fast=True)
+    scorer = FlairScorer(lang="de")
     return scorer
 
 


### PR DESCRIPTION
Since the `multi-v0` models are no longer available at [hu-berlin],
switch to the `de` model that is also used in production.

With this change, the tests pass again.

Fix https://github.com/pd3f/dehyphen/issues/4